### PR TITLE
Klumpen

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -44,7 +44,7 @@ mod 'role',
   :branch => 'klumpen'
 mod 'profile',
   :git => 'https://github.com/ntnusky/profile.git',
-  :tag => 'v1.4.2'
+  :branch => 'klumpen'
 mod 'ntnuopenstack',
   :git => 'https://github.com/ntnusky/ntnuopenstack.git',
   :tag => 'vQ.2.1'

--- a/Puppetfile
+++ b/Puppetfile
@@ -41,10 +41,10 @@ mod 'yelp/uchiwa', '2.1.0'
 # Our roles and profiles
 mod 'role',
   :git => 'https://github.com/ntnusky/role.git',
-  :branch => 'klumpen'
+  :tag => 'v1.1.0'
 mod 'profile',
   :git => 'https://github.com/ntnusky/profile.git',
-  :branch => 'klumpen'
+  :tag => 'v1.4.5'
 mod 'ntnuopenstack',
   :git => 'https://github.com/ntnusky/ntnuopenstack.git',
   :tag => 'vQ.2.1'

--- a/Puppetfile
+++ b/Puppetfile
@@ -47,7 +47,7 @@ mod 'profile',
   :tag => 'v1.4.2'
 mod 'ntnuopenstack',
   :git => 'https://github.com/ntnusky/ntnuopenstack.git',
-  :tag => 'vQ.2.0'
+  :tag => 'vQ.2.1'
 
 # Misc modules from git.
 mod 'ceph',

--- a/Puppetfile
+++ b/Puppetfile
@@ -41,7 +41,7 @@ mod 'yelp/uchiwa', '2.1.0'
 # Our roles and profiles
 mod 'role',
   :git => 'https://github.com/ntnusky/role.git',
-  :tag => 'v1.0.0'
+  :branch => 'klumpen'
 mod 'profile',
   :git => 'https://github.com/ntnusky/profile.git',
   :tag => 'v1.4.2'


### PR DESCRIPTION
This release adds:
 - role::klumpen
 - Hiera-key to configure the default vhost's docroot (profile::apache::vhost::default::docroot)
 - Hiera-key to configure mounts (profile::mounts)

This release removes:
 - role::controller
 - role::controller::step1
 - role::controller::step2
 - role::controller::step3
 - role::dns::master
 - role::dns::slave
 - role::manager
 - role::monitor
