### PR TITLE
Vmvg

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -44,7 +44,7 @@ mod 'role',
   :tag => 'v1.1.0'
 mod 'profile',
   :git => 'https://github.com/ntnusky/profile.git',
-  :branch => 'mountfix'
+  :tag => 'v1.4.7'
 mod 'ntnuopenstack',
   :git => 'https://github.com/ntnusky/ntnuopenstack.git',
   :tag => 'vQ.2.1'

--- a/Puppetfile
+++ b/Puppetfile
@@ -44,7 +44,7 @@ mod 'role',
   :tag => 'v1.1.0'
 mod 'profile',
   :git => 'https://github.com/ntnusky/profile.git',
-  :tag => 'v1.4.6'
+  :branch => 'mountfix'
 mod 'ntnuopenstack',
   :git => 'https://github.com/ntnusky/ntnuopenstack.git',
   :tag => 'vQ.2.1'

--- a/Puppetfile
+++ b/Puppetfile
@@ -44,7 +44,7 @@ mod 'role',
   :tag => 'v1.1.0'
 mod 'profile',
   :git => 'https://github.com/ntnusky/profile.git',
-  :tag => 'v1.4.5'
+  :tag => 'v1.4.6'
 mod 'ntnuopenstack',
   :git => 'https://github.com/ntnusky/ntnuopenstack.git',
   :tag => 'vQ.2.1'


### PR DESCRIPTION
Allow setting LVM VG name in hiera for role::kvm hosts.
Also a bugfix from profile v1.4.5 is fixed in v1.4.7