### PR TITLE
Ceph n (#175)

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -54,7 +54,7 @@ mod 'role',
   :tag => 'v1.3.2'
 mod 'profile',
   :git => 'https://github.com/ntnusky/profile.git',
-  :tag => 'v1.8.1'
+  :tag => 'v1.8.2'
 mod 'ntnuopenstack',
   :git => 'https://github.com/ntnusky/ntnuopenstack.git',
   :tag => 'vQ.4.0'
@@ -62,7 +62,7 @@ mod 'ntnuopenstack',
 # Misc modules from git.
 mod 'ceph',
   :git => 'https://github.com/openstack/puppet-ceph.git',
-  :commit => 'fbe1128ded9fdeac78b61b13d7597df1ee60c0c6'
+  :commit => 'a09926aa2d6c0127ca13eeb94303680c5eac86ea'
 mod 'dhcp',
   :git => 'https://github.com/voxpupuli/puppet-dhcp.git',
   :commit => 'b5925938188787faad99fdb52f294796e527a3d1'


### PR DESCRIPTION
Follow the needed modules for ceph Nautilus.

Upgrade-procedure: https://www.ntnu.no/wiki/display/skyhigh/Ceph+Luminous+to+Nautilus