### PR TITLE
Bonding

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -54,7 +54,7 @@ mod 'role',
   :tag => 'v1.3.2'
 mod 'profile',
   :git => 'https://github.com/ntnusky/profile.git',
-  :tag => 'v1.8.3'
+  :branch => 'bonding'
 mod 'ntnuopenstack',
   :git => 'https://github.com/ntnusky/ntnuopenstack.git',
   :tag => 'vQ.4.0'

--- a/Puppetfile
+++ b/Puppetfile
@@ -54,7 +54,7 @@ mod 'role',
   :tag => 'v1.3.2'
 mod 'profile',
   :git => 'https://github.com/ntnusky/profile.git',
-  :branch => 'bonding'
+  :tag => 'v1.9.0'
 mod 'ntnuopenstack',
   :git => 'https://github.com/ntnusky/ntnuopenstack.git',
   :tag => 'vQ.4.0'


### PR DESCRIPTION
Now a libvirt network is defined and connected to an openvswitch with the following information in hiera:

```
profile::kvm::networks:
  <networkname>:
    bridge: '<vswitch bridge>'
  <networkname>:
    bridge: '<vswitch bridge>'
    vlan: <VLAN ID>
```

To get the old structure where a dedicated interface is used for all libvirt
stuff to work you would need something similar to this in hiera:

```
profile::baseconfig::network::interfaces:
  eno2:
    ipv4:
      method: 'manual'
profile::baseconfig::network::bridges:
  br-vlan-eno2:
    external:
      type: 'interface'
      name: 'eno2'
profile::kvm::networks:
  infra:
    bridge: 'br-vlan-eno2'
    vlanid: 42
  storage:
    bridge: 'br-vlan-eno2'
    vlanid: 1337
```