### PR TITLE
Logrotate and munin-plugins

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -59,7 +59,7 @@ mod 'role',
   :tag => 'v1.8.0'
 mod 'profile',
   :git => 'https://github.com/ntnusky/profile.git',
-  :branch => 'logrotation'
+  :tag => 'v1.13.3'
 mod 'ntnuopenstack',
   :git => 'https://github.com/ntnusky/ntnuopenstack.git',
   :tag => 'vT.0.2'

--- a/Puppetfile
+++ b/Puppetfile
@@ -59,7 +59,7 @@ mod 'role',
   :tag => 'v1.8.0'
 mod 'profile',
   :git => 'https://github.com/ntnusky/profile.git',
-  :tag => 'v1.13.2'
+  :branch => 'logrotation'
 mod 'ntnuopenstack',
   :git => 'https://github.com/ntnusky/ntnuopenstack.git',
   :tag => 'vT.0.2'


### PR DESCRIPTION
This PR fixes some broken logrotation for some of our apache vhosts and updates the munin-plugins for ip-use to work with multiple subnets, and the format returned by openstack train.