### PR TITLE
Logging

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -73,7 +73,7 @@ mod 'role',
   :tag => 'v1.10.0'
 mod 'profile',
   :git => 'https://github.com/ntnusky/profile.git',
-  :tag => 'v1.19.8'
+  :branch => 'filebeat'
 mod 'ntnuopenstack',
   :git => 'https://github.com/ntnusky/ntnuopenstack.git',
   :tag => 'vV.1.0'

--- a/Puppetfile
+++ b/Puppetfile
@@ -78,7 +78,7 @@ mod 'profile',
   :branch => 'filebeat'
 mod 'ntnuopenstack',
   :git => 'https://github.com/ntnusky/ntnuopenstack.git',
-  :tag => 'vV.1.3'
+  :branch => 'logging'
 
 # Misc modules from git.
 mod 'openstack/ceph', '3.1.1'

--- a/Puppetfile
+++ b/Puppetfile
@@ -16,6 +16,7 @@ mod 'herculesteam-augeasproviders_shellvar', '4.0.0'
 mod 'inkblot/ipcalc', '2.2.0'
 mod 'lwf/remote_file', '1.1.3'
 mod 'nanliu/staging', "1.0.3"
+mod 'pcfens-filebeat', '4.11.0' # 07.06.2021
 mod 'puppetlabs/apache', "5.6.0"
 mod 'puppetlabs/apt', "7.1.0"
 mod 'puppetlabs/concat', "5.3.0"

--- a/Puppetfile
+++ b/Puppetfile
@@ -75,10 +75,10 @@ mod 'role',
   :tag => 'v1.10.0'
 mod 'profile',
   :git => 'https://github.com/ntnusky/profile.git',
-  :branch => 'filebeat'
+  :tag => 'v1.21.0'
 mod 'ntnuopenstack',
   :git => 'https://github.com/ntnusky/ntnuopenstack.git',
-  :branch => 'logging'
+  :tag => 'vV.2.0'
 
 # Misc modules from git.
 mod 'openstack/ceph', '3.1.1'


### PR DESCRIPTION
### Release overview

- Add sudo-config for ceph and rabbitmq administration.
- refacored users baseconf. Mainly to allow ssh-keys other than rsa.
- Add support to ship logs with filebeat to an external logging system.
- Set the memcache user to the correct setting, ensuring that it now can produce logs.
- Increase timeout for mysqls connections through haproxy, to be 1.5 times what openstack expects.
- Uses the latest defines from ntnusky/profile to set up log-shipping for openstack-services.

### Hiera changes

There are some new hiera-keys:

`profile::user`:  A Hash[String, Hash] where the string represents a username, and the hash within contains the user settings. Valid keys in the hash defining settings are "ensure" (present|absent, defaults to present), "groups" (list of groupnames, defaults to an empty list), "hash" (passwordhash), "purge_keys" (boolean which tells if puppet should purge unmanaged keys. Defaults to true), "uid" (the User ID) and "keys" (containing a hash[String, Hash] with a keyname as key and a hash with key data. The hash for key data needs the keys "type" and "key").
`profile::logstash::servers`: A list of logstash-servers which should recieve logs. Defaults to an empty list, resulting in no logging being set up.

And some keys being deprecated:

 - `profile::users`: the old list of usernames to manage, and a lot of keys describing the users settings:
 - `profile::user::${name}::uid`
 - `profile::user::${name}::ensure`
 - `profile::user::${name}::groups`
 - `profile::user::${name}::hash`
 - `profile::user::${name}::keys`
 - `profile::user::${name}::key::${name}`
 - `profile::user::${name}::purge::keys`