### PR TITLE
Wallaby and Provider Traits

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -109,46 +109,46 @@ mod 'tftp',
 # Openstack modules
 mod 'barbican',
   :git => 'https://github.com/openstack/puppet-barbican.git',
-  :branch => 'stable/victoria'
+  :branch => 'stable/wallaby'
 mod 'cinder',
   :git => 'https://github.com/openstack/puppet-cinder.git',
-  :branch => 'stable/victoria'
+  :branch => 'stable/wallaby'
 mod 'glance',
   :git => 'https://github.com/openstack/puppet-glance.git',
-  :branch => 'stable/victoria'
+  :branch => 'stable/wallaby'
 mod 'horizon',
   :git => 'https://github.com/openstack/puppet-horizon.git',
-  :branch => 'stable/victoria'
+  :branch => 'stable/wallaby'
 mod 'heat',
   :git => 'https://github.com/openstack/puppet-heat.git',
-  :branch => 'stable/victoria'
+  :branch => 'stable/wallaby'
 mod 'keystone',
   :git => 'https://github.com/openstack/puppet-keystone.git',
-  :branch => 'stable/victoria'
+  :branch => 'stable/wallaby'
 mod 'magnum',
   :git => 'https://github.com/openstack/puppet-magnum.git',
-  :branch => 'stable/victoria'
+  :branch => 'stable/wallaby'
 mod 'neutron',
   :git => 'https://github.com/openstack/puppet-neutron.git',
-  :branch => 'stable/victoria'
+  :branch => 'stable/wallaby'
 mod 'nova',
   :git => 'https://github.com/openstack/puppet-nova.git',
-  :branch => 'stable/victoria'
+  :branch => 'stable/wallaby'
 mod 'octavia',
   :git => 'https://github.com/openstack/puppet-octavia.git',
-  :branch => 'stable/victoria'
+  :branch => 'stable/wallaby'
 mod 'openstack_extras',
   :git => 'https://github.com/openstack/puppet-openstack_extras.git',
-  :branch => 'stable/victoria'
+  :branch => 'stable/wallaby'
 mod 'openstacklib',
   :git => 'https://github.com/openstack/puppet-openstacklib.git',
-  :branch => 'stable/victoria'
+  :branch => 'stable/wallaby'
 mod 'oslo',
   :git => 'https://github.com/openstack/puppet-oslo.git',
-  :branch => 'stable/victoria'
+  :branch => 'stable/wallaby'
 mod 'placement',
   :git => 'https://github.com/openstack/puppet-placement.git',
-  :branch => 'stable/victoria'
+  :branch => 'stable/wallaby'
 mod 'vswitch',
   :git => 'https://github.com/openstack/puppet-vswitch.git',
-  :branch => 'stable/victoria'
+  :branch => 'stable/wallaby'

--- a/Puppetfile
+++ b/Puppetfile
@@ -78,7 +78,7 @@ mod 'profile',
   :tag => 'v1.21.1'
 mod 'ntnuopenstack',
   :git => 'https://github.com/ntnusky/ntnuopenstack.git',
-  :tag => 'vW.0.0'
+  :branch => 'traits'
 
 # Misc modules from git.
 mod 'openstack/ceph', '3.1.1'

--- a/Puppetfile
+++ b/Puppetfile
@@ -78,7 +78,7 @@ mod 'profile',
   :tag => 'v1.21.1'
 mod 'ntnuopenstack',
   :git => 'https://github.com/ntnusky/ntnuopenstack.git',
-  :branch => 'wallaby'
+  :tag => 'vW.0.0'
 
 # Misc modules from git.
 mod 'openstack/ceph', '3.1.1'

--- a/Puppetfile
+++ b/Puppetfile
@@ -78,7 +78,7 @@ mod 'profile',
   :tag => 'v1.21.1'
 mod 'ntnuopenstack',
   :git => 'https://github.com/ntnusky/ntnuopenstack.git',
-  :branch => 'traits'
+  :tag => 'vW.1.0'
 
 # Misc modules from git.
 mod 'openstack/ceph', '3.1.1'

--- a/Puppetfile
+++ b/Puppetfile
@@ -74,10 +74,10 @@ mod 'role',
   :tag => 'v1.10.0'
 mod 'profile',
   :git => 'https://github.com/ntnusky/profile.git',
-  :tag => 'v1.20.0'
+  :branch => 'filebeat'
 mod 'ntnuopenstack',
   :git => 'https://github.com/ntnusky/ntnuopenstack.git',
-  :tag => 'vV.1.4'
+  :branch => 'wallaby'
 
 # Misc modules from git.
 mod 'openstack/ceph', '3.1.1'


### PR DESCRIPTION
- Changes needed for openstack Wallaby.
- Allow setting custom traits/inventories on the nodes providers.

Please consult our wiki for upgrade-guide.

### New hiera-keys:

Setting traits can be done like so:
```
ntnuopenstack::nova::compute::providers:
 - name: 'gpu01.infra.skylow.iik.ntnu.no'
   traits: [ 'CUSTOM_COMPUTE_GPU' ]
 - name: 'gpu01.infra.skylow.iik.ntnu.no_pci_0000_3d_00_0'
   traits: [ 'CUSTOM_M10_8G' ]
 - name: 'gpu01.infra.skylow.iik.ntnu.no_pci_0000_3e_00_0'
   traits: [ 'CUSTOM_M10_8G' ]
```

The wallaby-release of puppet-nova needs the database-string set in hiera:
```
nova::db::api_database_connection: "mysql+pymysql://nova_api:%{lookup('ntnuopenstack::nova::mysql::password')}@%{lookup('ntnuopenstack::nova::mysql::ip')}/nova_api"
nova::db::database_connection: "mysql+pymysql://nova:%{lookup('ntnuopenstack::nova::mysql::password')}@%{lookup('ntnuopenstack::nova::mysql::ip')}/nova"
```