### PR TITLE
 DUO, SL2, Netplan Bonds+VLANS, Partitioning

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -71,7 +71,7 @@ mod 'profile',
   :branch => 'socstack'
 mod 'ntnuopenstack',
   :git => 'https://github.com/ntnusky/ntnuopenstack.git',
-  :tag => 'vY.1.4'
+  :branch => 'modernization'
 
 
 # Misc modules from git.

--- a/Puppetfile
+++ b/Puppetfile
@@ -20,24 +20,24 @@ mod 'lwf/remote_file', '1.1.3'
 mod 'nanliu/staging', "1.0.3"
 mod 'pcfens-filebeat', '4.11.0' # 07.06.2021
 mod 'puppetlabs/apache', "7.0.0" # 11.10.2021
-mod 'puppetlabs/apt', "7.1.0"
+mod 'puppetlabs/apt', "9.0.2" # 14.03.2023
 mod 'puppetlabs/concat', "5.3.0"
 mod 'puppetlabs/firewall', "2.8.1"
 mod 'puppetlabs/facts', "1.4.0"
 mod 'puppetlabs/gcc', '0.3.0'
 mod 'puppetlabs/git', '0.5.0'
-mod 'puppetlabs/haproxy', "6.0.2" # 21.06.2021
+mod 'puppetlabs/haproxy', "8.0.0" # 22.11.2023
 mod 'puppetlabs/inifile', "2.5.0"
 mod 'puppetlabs/java', "1.6.0"
 mod 'puppetlabs/lvm', "1.4.0" # 12.02.2020
 mod 'puppetlabs/mysql', "12.0.3" # 25.05.2022
 mod 'puppetlabs/ntp', "9.0.1"
-mod 'puppetlabs/postgresql', "7.2.0" # 24.05.2021
-mod 'puppetlabs/puppet_agent', "4.7.0"
+mod 'puppetlabs/postgresql', "10.0.2" # 08.11.2023
+mod 'puppetlabs/puppet_agent', "4.15.0" # 21.09.2023
 mod 'puppetlabs/puppetdb', "7.8.0"
 mod 'puppetlabs/ruby', '1.0.0'
 mod 'puppetlabs/translate', '1.2.0'
-mod 'puppetlabs/stdlib', "8.5.0" # 13.10.2022
+mod 'puppetlabs/stdlib', "8.6.0" # 24.04.2023
 mod 'puppetlabs/vcsrepo', "1.3.2"
 mod 'puppetlabs/xinetd', "3.3.0" # 29.05.2019
 mod 'puppetlabs/yumrepo_core', "1.0.7"
@@ -45,19 +45,14 @@ mod 'puppet/archive', "3.0.0"
 mod 'puppet/dhcp', "4.0.1" # 23.08.2020
 mod 'puppet/logrotate', '6.0.0' # 28.09.2021
 mod 'puppet/make', '1.1.0'
-# Need to grab r10k from github when running puppet7, until they release a newer
-# version than v9. We need commit 1c054cc3c932b0a1fbd22510af28046d91a3490e
-#mod 'puppet/r10k', '9.0.0'
-mod 'r10k',
-  :git => 'https://github.com/voxpupuli/puppet-r10k.git',
-  :commit => 'c03a24e2555775887c171e4d52b899d6421d7da8'
+mod 'puppet/r10k', '11.0.1' # 08.06.2023
 mod 'puppet/rabbitmq', "11.1.0" # 06.05.2021
 mod 'puppet/redis', "4.0.0"
 mod 'puppet/selinux', '3.2.0'
 mod 'puppet/unattended_upgrades', "4.0.0"
 mod 'saz/memcached', "7.0.0" # 11.06.2021
-mod 'saz/ssh', "8.0.0" # 02.09.2021
-mod 'saz/sudo', "4.1.0"
+mod 'saz/ssh', "10.2.0" # 26.05.2023
+mod 'saz/sudo', "8.0.0" # 26.06.2023
 mod 'saz/timezone', '6.0.0'
 mod 'ssm/munin', '0.3.0'
 mod 'stm/debconf', '3.2.0'
@@ -65,18 +60,15 @@ mod 'sensu/sensu', '2.63.0'
 mod 'sgnl05/sssd', "0.3.1"
 mod 'treydock/yum_cron', "5.1.0"
 mod 'yelp/uchiwa', '2.1.0'
-#mod 'zehweh/netplan', '0.1.8'
-mod 'netplan',
-  :git => 'https://github.com/ntnusky/puppet-netplan.git',
-  :commit => 'a134654121e0432d8a4dd9009be3bad1ab6fc27d'
+mod 'zehweh/netplan', '2.0.0'
 
 # Our roles and profiles
 mod 'role',
   :git => 'https://github.com/ntnusky/role.git',
-  :tag => 'v1.10.0'
+  :branch => 'socstack'
 mod 'profile',
   :git => 'https://github.com/ntnusky/profile.git',
-  :tag => 'v1.23.1'
+  :branch => 'socstack'
 mod 'ntnuopenstack',
   :git => 'https://github.com/ntnusky/ntnuopenstack.git',
   :tag => 'vY.1.4'
@@ -107,9 +99,12 @@ mod 'os',
 mod 'rrd',
   :git => 'https://github.com/ntnusky/puppet-rrd.git',
   :commit => 'f0d6be1f932d4b9c3db2da4ba21930519875ed06'
+mod 'shiftleader',
+  :git => 'https://github.com/shiftleader2/puppet-shiftleader',
+  :branch => 'main'
 mod 'srvadmin',
   :git => 'https://github.com/ntnusky/puppet-srvadmin.git',
-  :tag => 'v1.2.0'
+  :branch => 'jammy'
 mod 'tftp',
   :git => 'https://github.com/puppetlabs/puppetlabs-tftp',
   :commit => '91f8a291ea4b6ff366c0dcf9f2b09b9cd8841568'

--- a/Puppetfile
+++ b/Puppetfile
@@ -65,13 +65,13 @@ mod 'zehweh/netplan', '2.0.0'
 # Our roles and profiles
 mod 'role',
   :git => 'https://github.com/ntnusky/role.git',
-  :branch => 'socstack'
+  :tag => 'v1.11.0'
 mod 'profile',
   :git => 'https://github.com/ntnusky/profile.git',
-  :branch => 'socstack'
+  :tag => 'v1.24.0'
 mod 'ntnuopenstack',
   :git => 'https://github.com/ntnusky/ntnuopenstack.git',
-  :branch => 'modernization'
+  :tag => 'vY.4.0'
 
 
 # Misc modules from git.

--- a/Puppetfile
+++ b/Puppetfile
@@ -112,46 +112,46 @@ mod 'tftp',
 # Openstack modules
 mod 'barbican',
   :git => 'https://github.com/openstack/puppet-barbican.git',
-  :branch => 'stable/yoga'
+  :branch => 'unmaintained/yoga'
 mod 'cinder',
   :git => 'https://github.com/openstack/puppet-cinder.git',
-  :branch => 'stable/yoga'
+  :branch => 'unmaintained/yoga'
 mod 'glance',
   :git => 'https://github.com/openstack/puppet-glance.git',
-  :branch => 'stable/yoga'
+  :branch => 'unmaintained/yoga'
 mod 'horizon',
   :git => 'https://github.com/openstack/puppet-horizon.git',
-  :branch => 'stable/yoga'
+  :branch => 'unmaintained/yoga'
 mod 'heat',
   :git => 'https://github.com/openstack/puppet-heat.git',
-  :branch => 'stable/yoga'
+  :branch => 'unmaintained/yoga'
 mod 'keystone',
   :git => 'https://github.com/openstack/puppet-keystone.git',
-  :branch => 'stable/yoga'
+  :branch => 'unmaintained/yoga'
 mod 'magnum',
   :git => 'https://github.com/openstack/puppet-magnum.git',
-  :branch => 'stable/yoga'
+  :branch => 'unmaintained/yoga'
 mod 'neutron',
   :git => 'https://github.com/openstack/puppet-neutron.git',
-  :branch => 'stable/yoga'
+  :branch => 'unmaintained/yoga'
 mod 'nova',
   :git => 'https://github.com/openstack/puppet-nova.git',
-  :branch => 'stable/yoga'
+  :branch => 'unmaintained/yoga'
 mod 'octavia',
   :git => 'https://github.com/openstack/puppet-octavia.git',
-  :branch => 'stable/yoga'
+  :branch => 'unmaintained/yoga'
 mod 'openstack_extras',
   :git => 'https://github.com/openstack/puppet-openstack_extras.git',
-  :branch => 'stable/yoga'
+  :branch => 'unmaintained/yoga'
 mod 'openstacklib',
   :git => 'https://github.com/openstack/puppet-openstacklib.git',
-  :branch => 'stable/yoga'
+  :branch => 'unmaintained/yoga'
 mod 'oslo',
   :git => 'https://github.com/openstack/puppet-oslo.git',
-  :branch => 'stable/yoga'
+  :branch => 'unmaintained/yoga'
 mod 'placement',
   :git => 'https://github.com/openstack/puppet-placement.git',
-  :branch => 'stable/yoga'
+  :branch => 'unmaintained/yoga'
 mod 'vswitch',
   :git => 'https://github.com/openstack/puppet-vswitch.git',
-  :branch => 'stable/yoga'
+  :branch => 'unmaintained/yoga'


### PR DESCRIPTION
# Changes

 - Changed CPU model number for the Icelake-Server-NTNU profile.
 - Add configuration for DUO 2fa
 - Add support for increasing lvm partition-size based on hiera
 - Add bonds and vlans to our netplan config 
 - Add the interface address method 'shiftleader' to staticly configure the
   address given from the shiftleader ENC.
 - Add BGP MED to bird to prioritize certain anycast-points over others.
 - Creation of haproxy-backends for munin/sensu/redis is now only done if the
   service is actually needed.
 - Ports are now given to haproxy-backends as strings.
 - The hiera-key `profile::interfaces::management` can now be omitted if
   shiftleader2 is used, as the value can come from shiftleader.
 - Add the possibility to serve TLS-web through haproxy using the nodes
   puppet-cert.
 - Add support for having multiple LVM VG's as storage-pools for our libvirt
   profiles.
 - The info-vhost is now optional on the shiftleader-boxes; and is skipped if no value is provided to `profile::info::maillist::fqdn`
 - Munin-profiles are updated to be compatible with SL2
 - Munin-node firewall now opens to all infrastructure-networks, and not just only the main infra-network. 
 - IPv6 gateways can now be set through hiera for netplan
 - Installation of the shiftleader2-client is now possible by setting the `profile::shiftleader2::client::install` key to true in hiera

# Breaking changes:

 - Due to dependency-cycles we cannot set postgresql::globals parameters in
   puppet-code at the moment. The following two lines MUST thus be placed in
   hiera:
   ```
   postgresql::globals::version: "%{alias('profile::postgres::version')}"
   postgresql::globals::manage_package_repo: true
   ```

# New Hiera-keys

 - `profile::baseconfig::network::bonds`: A hash describing bonds. Support the
              same parameters for methods, addresses etc as the interfaces hash,
              in addition to the keys 'parameters' and 'interfaces' which sets
              the bonding settings. 
 - `profile::baseconfig::network::vlans`: A hash describing VLANs. Support the 
              same parameters for methods, addresses etc as the interfaces hash,
              in addition to the keys 'parent' and 'vlanid' which sets the VLAN
              settings.
 - `profile::bird::anycast::med`: The desired MED value for BGP routes from
              bird. Defaults to 500.
 - `profile::dns::resolvers`: A list of IP-adresses for DNS resolvers
 - `profile::dns::searchdomains`: A list of DNS search-domains. It replaces the 
              key `profile::dns::searchdomain` which only support a single key.
 - `profile::disk::root::size`: Desired size of the root-partition.
 - `profile::disk::swap::size`: Desired size of the swap-partition.
 - `profile::disk::var::size`: Desired size of the var-partition.
 - `profile::duo::enabled`: Boolean controlling if duo should be installed.
                            Defaults to false.
 - `profile::duo::api::hostname`: Which DUO Hostname to use for 2fa
 - `profile::duo::api::integration`: Duo integrationID 
 - `profile::duo::api::secret`: Duo secret 
 - `profile::haproxy::tls::puppetcert`: A Boolean telling haproxy to include the
              puppet-cert in its web-frontend. Used for puppet-reporting.
 - `profile::kvm::vgs`: A list of strings, which represents LVM VG's.
 - `profile::ldap::server`: LDAP-settings used for authenticating SL users.
 - `profile::ldap::bind::user`
 - `profile::ldap::bind::password`
 - `profile::ldap::group::attribute::member`
 - `profile::ldap::group::base`
 - `profile::ldap::user::attribute::id`
 - `profile::ldap::user::base`
 - `profile::shiftleader::client::install`  - Controls if shiftleader should be installed.
 - `profile::shiftleader::major::version`: An integer expressing which SL major
              version we have installed. Defaults to 1.
 - `profile::ssh::public`: A boolean stating if the SSH server is publicly
              available. If true there will be som extra hardening like only
              allowing 2fa keys, and dont allow the host-based auth for
              nova/postgres. Defaults to false.

# Deprecated Hiera-keys:

 - `profile::dns::searchdomain`: Replaced by `profile::dns::searchdomains`
 - `profile::dns::nameservers`: Replaced by `profile::dns::resolvers`
 - `profile::kvm::vmvg::name`: Replaced by `profile::kvm::vgs`

# Removed Hiera-keys:
 - `profile::ceph::osds` - We do not auto-provison OSD's with puppet anymore.