### PR TITLE
Tuning og MySQL

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -71,7 +71,7 @@ mod 'role',
   :tag => 'v1.14.0'
 mod 'profile',
   :git => 'https://github.com/ntnusky/profile.git',
-  :tag => 'v1.29.2'
+  :branch => 'tuning'
 mod 'ntnuopenstack',
   :git => 'https://github.com/ntnusky/ntnuopenstack.git',
   :tag => 'vC.0.0'

--- a/Puppetfile
+++ b/Puppetfile
@@ -71,7 +71,7 @@ mod 'role',
   :tag => 'v1.14.0'
 mod 'profile',
   :git => 'https://github.com/ntnusky/profile.git',
-  :branch => 'tuning'
+  :tag => 'v1.29.3'
 mod 'ntnuopenstack',
   :git => 'https://github.com/ntnusky/ntnuopenstack.git',
   :tag => 'vC.0.0'


### PR DESCRIPTION
This tuning of the MySQL-clusters provides us with:

- A lot better read-performance in large databases
- Better write-performance, due to fewer reads hitting our disks.
- More time to recover failed galera-servers without needing to do a full resync.

### New hiera-keys:

- `profile::mysql::innodb_buffer_pool_size`: Increase the default pool-size a good bit, and allow setting it in hiera if we need a further increase.
- `profile::mysql::thread_handling`: Allows us to override this setting through hiera.
- `profile::mysql::thread_pool_size`: Allows us to override this setting through hiera.
- `profile::mysql::key_buffer_size`: Increse the default buffer and allows us to override this setting through hiera.
- `profile::mysql::max_heap_table_size`: Increse the default buffer and allows us to override this setting through hiera.
- `profile::mysql::tmp_table_size`: Increse the default buffer and allows us to override this setting through hiera.
- `profile::mysql::wsrep::gcache`: Increse the default buffer and allows us to override this setting through hiera.