### PR TITLE
Puppet8 compatibility

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -2,7 +2,6 @@ forge "http://forge.puppetlabs.com"
 
 # Comments are the release date for the version used (dd.mm.yyyy)
 
-mod 'aboe/chrony', '0.3.2'
 mod 'arioch/keepalived', "1.2.5"
 mod 'camptocamp/kmod', "2.3.1"
 mod 'deric/zookeeper', '1.6.0' # 22.01.2025
@@ -44,6 +43,7 @@ mod 'puppetlabs/vcsrepo', "7.0.0" # 26.02.2025
 mod 'puppetlabs/xinetd', "3.4.1" # 18.07.2023
 mod 'puppetlabs/yumrepo_core', "2.1.0" # 07.03.2024
 mod 'puppet/archive', "3.0.0"
+mod 'puppet/chrony', '5.0.0' # 27.11.2025
 mod 'puppet/dhcp', "6.1.0" # 23.01.2024
 mod 'puppet/logrotate', '6.0.0' # 28.09.2021
 mod 'puppet/make', '1.1.0'

--- a/Puppetfile
+++ b/Puppetfile
@@ -51,7 +51,7 @@ mod 'puppet/r10k', '14.3.0' # 18.05.2025
 mod 'puppet/rabbitmq', "14.4.1" # 20.06.2025
 mod 'puppet/selinux', '3.2.0'
 mod 'puppet/systemd', '8.2.0' # 19.04.2025
-mod 'puppet/unattended_upgrades', "4.0.0"
+mod 'puppet/unattended_upgrades', "9.1.0" # 27.11.2025
 mod 'puppet/zabbix', "10.0.0" # 15.03.2024
 mod 'saz/locales', '4.1.0' # 05.02.2025
 mod 'saz/memcached', "10.0.1" # 10.03.2025

--- a/Puppetfile
+++ b/Puppetfile
@@ -35,7 +35,7 @@ mod 'puppetlabs/mysql', "16.3.0" # 30.07.2025
 mod 'puppetlabs/ntp', "9.0.1"
 mod 'puppetlabs/postgresql', "10.5.0" # 07.01.2025
 mod 'puppetlabs/puppet_agent', "4.21.0" # 25.09.2024 Nyere enn dette krever apt >=10, men det vil ikke openstack_extras @ 2024.1 ha
-mod 'puppetlabs/puppetdb', "7.8.0"
+mod 'puppetlabs/puppetdb', "8.1.0" # 07.05.2024
 mod 'puppetlabs/ruby', '1.0.0'
 mod 'puppetlabs/translate', '1.2.0'
 mod 'puppetlabs/stdlib', "9.7.0" # 17.12.2024

--- a/Puppetfile
+++ b/Puppetfile
@@ -70,7 +70,7 @@ mod 'role',
   :tag => 'v1.15.0'
 mod 'profile',
   :git => 'https://github.com/ntnusky/profile.git',
-  :tag => 'v1.30.8'
+  :branch => 'puppet8'
 mod 'ntnuopenstack',
   :git => 'https://github.com/ntnusky/ntnuopenstack.git',
   :tag => 'vE.0.1'

--- a/Puppetfile
+++ b/Puppetfile
@@ -44,6 +44,7 @@ mod 'puppetlabs/yumrepo_core', "2.1.0" # 07.03.2024
 mod 'puppet/archive', "3.0.0"
 mod 'puppet/chrony', '5.0.0' # 27.11.2025
 mod 'puppet/dhcp', "6.1.0" # 23.01.2024
+mod 'puppet/extlib', "7.5.1" # 18.02.2025
 mod 'puppet/logrotate', '6.0.0' # 28.09.2021
 mod 'puppet/make', '1.1.0'
 mod 'puppet/r10k', '14.3.0' # 18.05.2025

--- a/Puppetfile
+++ b/Puppetfile
@@ -34,7 +34,6 @@ mod 'puppetlabs/lvm', "1.4.0" # 12.02.2020
 mod 'puppetlabs/mysql', "16.3.0" # 30.07.2025
 mod 'puppetlabs/ntp', "9.0.1"
 mod 'puppetlabs/postgresql', "10.5.0" # 07.01.2025
-mod 'puppetlabs/puppet_agent', "4.21.0" # 25.09.2024 Nyere enn dette krever apt >=10, men det vil ikke openstack_extras @ 2024.1 ha
 mod 'puppetlabs/puppetdb', "8.1.0" # 07.05.2024
 mod 'puppetlabs/ruby', '1.0.0'
 mod 'puppetlabs/translate', '1.2.0'
@@ -60,7 +59,8 @@ mod 'saz/sudo', "8.0.0" # 26.06.2023
 mod 'saz/timezone', '6.0.0'
 mod 'stm/debconf', '3.2.0'
 mod 'sgnl05/sssd', "0.3.1"
-mod 'theforeman-dns', '11.1.0' # 09.05.2025
+mod 'theforeman/dns', '11.1.0' # 09.05.2025
+mod 'theforeman/puppet', '22.1.0' # 27.01.2026
 mod 'treydock/yum_cron', "5.1.0"
 mod 'zehweh/netplan', '2.0.0'
 

--- a/Puppetfile
+++ b/Puppetfile
@@ -94,7 +94,7 @@ mod 'rrd',
   :commit => 'f0d6be1f932d4b9c3db2da4ba21930519875ed06'
 mod 'shiftleader',
   :git => 'https://github.com/shiftleader2/puppet-shiftleader',
-  :branch => 'main'
+  :branch => 'puppet8'
 mod 'srvadmin',
   :git => 'https://github.com/ntnusky/puppet-srvadmin.git',
   :branch => 'noble'

--- a/Puppetfile
+++ b/Puppetfile
@@ -73,7 +73,7 @@ mod 'profile',
   :branch => 'puppet8'
 mod 'ntnuopenstack',
   :git => 'https://github.com/ntnusky/ntnuopenstack.git',
-  :tag => 'vE.0.1'
+  :branch => 'puppet8'
 
 # Misc modules from git.
 mod 'hpacucli',

--- a/Puppetfile
+++ b/Puppetfile
@@ -62,6 +62,7 @@ mod 'stm/debconf', '3.2.0'
 mod 'sgnl05/sssd', "0.3.1"
 mod 'theforeman/dns', '11.1.0' # 09.05.2025
 mod 'theforeman/puppet', '22.1.0' # 27.01.2026
+mod 'theforeman/tftp', '10.0.0' # 08.08.2025
 mod 'treydock/yum_cron', "5.1.0"
 mod 'zehweh/netplan', '2.0.0'
 
@@ -98,9 +99,6 @@ mod 'shiftleader',
 mod 'srvadmin',
   :git => 'https://github.com/ntnusky/puppet-srvadmin.git',
   :branch => 'noble'
-mod 'tftp',
-  :git => 'https://github.com/puppetlabs/puppetlabs-tftp',
-  :commit => '91f8a291ea4b6ff366c0dcf9f2b09b9cd8841568'
 
 # Openstack modules
 mod 'barbican',

--- a/Puppetfile
+++ b/Puppetfile
@@ -79,7 +79,7 @@ mod 'ntnuopenstack',
 # Misc modules from git.
 mod 'hpacucli',
   :git => 'https://github.com/ntnusky/puppet-hpacucli.git',
-  :tag => '0.5.1'
+  :tag => '0.6.0'
 mod 'hwraid',
   :git => 'https://github.com/ntnusky/puppet-hwraid.git',
   :commit => '45738374a83ff22f7a4cab946fa9bf47fee61fea'

--- a/Puppetfile
+++ b/Puppetfile
@@ -62,6 +62,7 @@ mod 'stm/debconf', '3.2.0'
 mod 'sgnl05/sssd', "0.3.1"
 mod 'theforeman/dns', '11.1.0' # 09.05.2025
 mod 'theforeman/puppet', '22.1.0' # 27.01.2026
+mod 'thias/libvirt', '1.0.3'  #04.02.2025
 mod 'treydock/yum_cron', "5.1.0"
 mod 'zehweh/netplan', '2.0.0'
 
@@ -83,9 +84,6 @@ mod 'hpacucli',
 mod 'hwraid',
   :git => 'https://github.com/ntnusky/puppet-hwraid.git',
   :commit => '45738374a83ff22f7a4cab946fa9bf47fee61fea'
-mod 'libvirt',
-  :git => 'https://github.com/ntnusky/puppet-libvirt.git',
-  :branch => 'jammy'
 mod 'os',
   :git => 'https://github.com/Puppet-Finland/os.git',
   :commit => 'acaa49115fb0bb8bb0742df21144357382181f41'

--- a/Puppetfile
+++ b/Puppetfile
@@ -72,10 +72,10 @@ mod 'role',
   :tag => 'v1.15.0'
 mod 'profile',
   :git => 'https://github.com/ntnusky/profile.git',
-  :branch => 'puppet8'
+  :tag => 'v1.31.0'
 mod 'ntnuopenstack',
   :git => 'https://github.com/ntnusky/ntnuopenstack.git',
-  :branch => 'puppet8'
+  :tag => 'vE.1.0'
 
 # Misc modules from git.
 mod 'hpacucli',
@@ -95,7 +95,7 @@ mod 'rrd',
   :commit => 'f0d6be1f932d4b9c3db2da4ba21930519875ed06'
 mod 'shiftleader',
   :git => 'https://github.com/shiftleader2/puppet-shiftleader',
-  :branch => 'puppet8'
+  :tag => 'v1.1.0'
 mod 'srvadmin',
   :git => 'https://github.com/ntnusky/puppet-srvadmin.git',
   :branch => 'noble'

--- a/Puppetfile
+++ b/Puppetfile
@@ -72,7 +72,7 @@ mod 'role',
   :tag => 'v1.15.0'
 mod 'profile',
   :git => 'https://github.com/ntnusky/profile.git',
-  :tag => 'v1.31.0'
+  :tag => 'v1.31.1'
 mod 'ntnuopenstack',
   :git => 'https://github.com/ntnusky/ntnuopenstack.git',
   :tag => 'vE.1.0'

--- a/Puppetfile
+++ b/Puppetfile
@@ -62,7 +62,6 @@ mod 'stm/debconf', '3.2.0'
 mod 'sgnl05/sssd', "0.3.1"
 mod 'theforeman/dns', '11.1.0' # 09.05.2025
 mod 'theforeman/puppet', '22.1.0' # 27.01.2026
-mod 'thias/libvirt', '1.0.3'  #04.02.2025
 mod 'treydock/yum_cron', "5.1.0"
 mod 'zehweh/netplan', '2.0.0'
 
@@ -84,6 +83,9 @@ mod 'hpacucli',
 mod 'hwraid',
   :git => 'https://github.com/ntnusky/puppet-hwraid.git',
   :commit => '45738374a83ff22f7a4cab946fa9bf47fee61fea'
+mod 'libvirt',
+  :git => 'https://github.com/ntnusky/puppet-libvirt.git',
+  :branch => 'jammy'
 mod 'os',
   :git => 'https://github.com/Puppet-Finland/os.git',
   :commit => 'acaa49115fb0bb8bb0742df21144357382181f41'


### PR DESCRIPTION
# Changes

 - Adding support for openvox8

## New hiera-keys:

 - `profile::openvox::release`: Which openvox-release to conifigure apt-repositories for. Defaults to "openvox8".
