### PR TITLE
Dirtyfrag

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -72,7 +72,7 @@ mod 'role',
   :tag => 'v1.15.0'
 mod 'profile',
   :git => 'https://github.com/ntnusky/profile.git',
-  :tag => 'v1.31.1'
+  :branch => 'dirtyfrag'
 mod 'ntnuopenstack',
   :git => 'https://github.com/ntnusky/ntnuopenstack.git',
   :tag => 'vE.1.0'

--- a/Puppetfile
+++ b/Puppetfile
@@ -72,7 +72,7 @@ mod 'role',
   :tag => 'v1.15.0'
 mod 'profile',
   :git => 'https://github.com/ntnusky/profile.git',
-  :branch => 'dirtyfrag'
+  :tag => 'v1.31.2'
 mod 'ntnuopenstack',
   :git => 'https://github.com/ntnusky/ntnuopenstack.git',
   :tag => 'vE.1.0'


### PR DESCRIPTION
# Changed

Parameterize the copyfail mitigation to allow future mitigations without creating new releases.

## New hiera-keys:

 - `profile::kmod::blocklist`: List of modules that need to be disabled. Defaults to the modules needed to be removed to mitigate the copyfail and dirtyfrag bugs.
 - `profile::kmod::blocklist::cleanup`: List of modules that dont need to be disabled anymore. Can be used to remove an earlier disabling of such modules. Defaults to clean up the first attempt to disable copyfail, as that disablement now uses a different file-name.

## Removed hiera-keys:

 - `profile::mitigation::copyfail`: As the disabling of modules now are parameterized the old opt-out variable is not used anymore.