### PR TITLE
Nohwraid

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -72,7 +72,7 @@ mod 'role',
   :tag => 'v1.15.0'
 mod 'profile',
   :git => 'https://github.com/ntnusky/profile.git',
-  :tag => 'v1.31.2'
+  :branch => 'nohwraid'
 mod 'ntnuopenstack',
   :git => 'https://github.com/ntnusky/ntnuopenstack.git',
   :tag => 'vE.1.0'
@@ -81,15 +81,9 @@ mod 'ntnuopenstack',
 mod 'hpacucli',
   :git => 'https://github.com/ntnusky/puppet-hpacucli.git',
   :tag => '0.6.0'
-mod 'hwraid',
-  :git => 'https://github.com/ntnusky/puppet-hwraid.git',
-  :commit => '45738374a83ff22f7a4cab946fa9bf47fee61fea'
 mod 'libvirt',
   :git => 'https://github.com/ntnusky/puppet-libvirt.git',
   :branch => 'jammy'
-mod 'os',
-  :git => 'https://github.com/Puppet-Finland/os.git',
-  :commit => 'acaa49115fb0bb8bb0742df21144357382181f41'
 mod 'rrd',
   :git => 'https://github.com/ntnusky/puppet-rrd.git',
   :commit => 'f0d6be1f932d4b9c3db2da4ba21930519875ed06'

--- a/Puppetfile
+++ b/Puppetfile
@@ -72,7 +72,7 @@ mod 'role',
   :tag => 'v1.15.0'
 mod 'profile',
   :git => 'https://github.com/ntnusky/profile.git',
-  :branch => 'nohwraid'
+  :tag => 'v1.31.3'
 mod 'ntnuopenstack',
   :git => 'https://github.com/ntnusky/ntnuopenstack.git',
   :tag => 'vE.1.0'


### PR DESCRIPTION
Removed puppet-hwraid and its dependency puppet-os, as none of them really work for Openvox 8, and the packages we tried to install with these modules is not supported on Ubuntu versions newer than 22.04.