### PR TITLE
Puppetdbtermini

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -72,7 +72,7 @@ mod 'role',
   :tag => 'v1.15.0'
 mod 'profile',
   :git => 'https://github.com/ntnusky/profile.git',
-  :tag => 'v1.31.2'
+  :branch => 'puppetdbtermini'
 mod 'ntnuopenstack',
   :git => 'https://github.com/ntnusky/ntnuopenstack.git',
   :tag => 'vE.1.0'

--- a/Puppetfile
+++ b/Puppetfile
@@ -73,7 +73,7 @@ mod 'role',
   :tag => 'v1.15.0'
 mod 'profile',
   :git => 'https://github.com/ntnusky/profile.git',
-  :branch => 'puppetdbtermini'
+  :tag => 'v1.31.5'
 mod 'ntnuopenstack',
   :git => 'https://github.com/ntnusky/ntnuopenstack.git',
   :tag => 'vE.2.0'


### PR DESCRIPTION
Allow inter-region access to puppetdb, and install a missing package for the puppetdb-termini when using openvox.